### PR TITLE
Add layered configuration support

### DIFF
--- a/docs/sample.toml
+++ b/docs/sample.toml
@@ -9,3 +9,6 @@ CC = "gcc-11"		# Set CC='gcc-11' in the environment at configure time
 jobs = 6		# Always build with 6 parallel jobs
 
 copy_cc = true		# Copy `compile_commands.json` to project root on build
+
+[meta]
+ignore_global = true    # Ignore options from the global configuration

--- a/src/emake/core/settings.py
+++ b/src/emake/core/settings.py
@@ -5,11 +5,11 @@ try:
 except ModuleNotFoundError:
     import tomli as tomllib
 
-from typing import Dict
 from benedict import benedict
+from typing import Union, Dict
 
 
-def __get_opts(config: Path) -> Dict:
+def __get_opts(config: Path) -> Union[Dict[str, Any], Dict]:
     """ Get values from given TOML configuration. """
 
     try:

--- a/src/emake/core/settings.py
+++ b/src/emake/core/settings.py
@@ -9,8 +9,8 @@ from benedict import benedict
 from typing import Union, Dict, Any
 
 
-def __get_opts(config: Path) -> Union[Dict[str, Any], Dict]:
-    """ Get values from given TOML configuration. """
+def _get_opts(config: Path) -> Union[Dict[str, Any], Dict]:
+    """ Get values from a given TOML configuration. """
 
     try:
         with config.open("rb") as f:
@@ -27,8 +27,8 @@ def default() -> benedict:
     local_path = Path("emake.toml")
     global_path = Path.home().joinpath(".config", "emake.toml")
 
-    local_opts = __get_opts(local_path)
-    global_opts = __get_opts(global_path)
+    local_opts = _get_opts(local_path)
+    global_opts = _get_opts(global_path)
 
     defaults = benedict(local_opts)
     defaults.merge(global_opts, concat=True)

--- a/src/emake/core/settings.py
+++ b/src/emake/core/settings.py
@@ -5,21 +5,32 @@ try:
 except ModuleNotFoundError:
     import tomli as tomllib
 
+from typing import Dict
 from benedict import benedict
-from typing import Dict, List, Optional
+
+
+def __get_opts(config: Path) -> Dict:
+    """ Get values from given TOML configuration. """
+
+    try:
+        with config.open("rb") as f:
+            data = tomllib.load(f)
+    except FileNotFoundError:
+        data = {}
+
+    return data
 
 
 def default() -> benedict:
     """Load user settings from the default path(s)."""
 
-    settings_path = Path("emake.toml")
-    if not settings_path.is_file():
-        settings_path = Path.home().joinpath(".config", "emake.toml")
+    local_path = Path("emake.toml")
+    global_path = Path.home().joinpath(".config", "emake.toml")
 
-    try:
-        with open(settings_path, "rb") as f:
-            raw = tomllib.load(f)
-    except FileNotFoundError:
-        raw = {}
+    local_opts = __get_opts(local_path)
+    global_opts = __get_opts(global_path)
 
-    return benedict(raw)
+    defaults = benedict(local_opts)
+    defaults.merge(global_opts, concat=True)
+
+    return defaults

--- a/src/emake/core/settings.py
+++ b/src/emake/core/settings.py
@@ -6,7 +6,7 @@ except ModuleNotFoundError:
     import tomli as tomllib
 
 from benedict import benedict
-from typing import Union, Dict
+from typing import Union, Dict, Any
 
 
 def __get_opts(config: Path) -> Union[Dict[str, Any], Dict]:

--- a/src/emake/core/settings.py
+++ b/src/emake/core/settings.py
@@ -31,6 +31,7 @@ def default() -> benedict:
     global_opts = _get_opts(global_path)
 
     defaults = benedict(local_opts)
-    defaults.merge(global_opts, concat=True)
+    if not defaults.get_bool("meta.ignore_global"):
+        defaults.merge(global_opts, concat=True)
 
     return defaults


### PR DESCRIPTION
Resolves #1. With the newly added module, `python-benedict`, it's possible to read both configurations (if present) and combine the values for them to be accessed.

Currently, there's no way to disable this behavior, as introducing a new flag for this feature is yet to be discussed (hence this PR being a draft). If either file doesn't exist, no custom values will be used when running `emake` or `econf`.